### PR TITLE
Update documentation to reflect Dogecoin rather than Bitcoin

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -28,7 +28,7 @@ DOXYFILE_ENCODING      = UTF-8
 # The PROJECT_NAME tag is a single word (or a sequence of words surrounded 
 # by quotes) that should identify the project.
 
-PROJECT_NAME           = Dogecoin
+PROJECT_NAME           = Inutoshi
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. 
 # This could be handy for archiving the generated documentation or 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -28,13 +28,13 @@ DOXYFILE_ENCODING      = UTF-8
 # The PROJECT_NAME tag is a single word (or a sequence of words surrounded 
 # by quotes) that should identify the project.
 
-PROJECT_NAME           = Bitcoin
+PROJECT_NAME           = Dogecoin
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. 
 # This could be handy for archiving the generated documentation or 
 # if some version control system is used.
 
-PROJECT_NUMBER         = 0.9.99
+PROJECT_NUMBER         = 1.7.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description 
 # for a project that appears at the top of each page and should give viewer 

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@ Copyright (c) 2009-2014 Bitcoin Developers
 
 Setup
 ---------------------
-[Dogecoin Core](http://bitcoin.org/en/download) is the original Dogecoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Dogecoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more. Thankfully you only have to do this once. If you would like the process to go faster you can [download the blockchain directly](https://bitcointalk.org/index.php?topic=145386.0).
+[Dogecoin Core](http://dogecoin.com/en/download) is the original Dogecoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Dogecoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more. Thankfully you only have to do this once.
 
 Running
 ---------------------
@@ -35,10 +35,10 @@ Drag Dogecoin-Qt to your applications folder, and then run Dogecoin-Qt.
 
 ### Need Help?
 
-* See the documentation at the [Dogecoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
+* See the documentation at the [Dogecoin Wiki](http://dogeco.in/)
 for help and more information.
-* Ask for help on [#bitcoin](http://webchat.freenode.net?channels=bitcoin) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net?channels=bitcoin).
-* Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
+* Ask for help on [#dogecoin](http://webchat.freenode.net?channels=dogecoin) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net?channels=dogecoin).
+* Ask for help on the [/r/dogeducation subreddit](http://reddit.com/r/dogeducation).
 
 Building
 ---------------------
@@ -50,7 +50,7 @@ The following are developer notes on how to build Dogecoin on your native platfo
 
 Development
 ---------------------
-The Dogecoin repo's [root README](https://github.com/bitcoin/bitcoin/blob/master/README.md) contains relevant information on the development process and automated testing.
+The Dogecoin repo's [root README](https://github.com/dogecoin/dogecoin/blob/master/README.md) contains relevant information on the development process and automated testing.
 
 - [Coding Guidelines](coding.md)
 - [Multiwallet Qt Development](multiwallet-qt.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -20,14 +20,14 @@ You need the Qt4 run-time libraries to run Dogecoin-Qt. On Debian or Ubuntu:
 
 Unpack the files into a directory and run:
 
-- bin/32/bitcoin-qt (GUI, 32-bit) or bin/32/bitcoind (headless, 32-bit)
-- bin/64/bitcoin-qt (GUI, 64-bit) or bin/64/bitcoind (headless, 64-bit)
+- bin/32/dogecoin-qt (GUI, 32-bit) or bin/32/dogecoind (headless, 32-bit)
+- bin/64/dogecoin-qt (GUI, 64-bit) or bin/64/dogecoind (headless, 64-bit)
 
 
 
 ### Windows
 
-Unpack the files into a directory, and then run bitcoin-qt.exe.
+Unpack the files into a directory, and then run dogecoin-qt.exe.
 
 ### OSX
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,4 +1,4 @@
-Bitcoin 0.9.0 BETA
+Dogecoin 0.9.0 BETA
 =====================
 
 Copyright (c) 2009-2014 Bitcoin Developers
@@ -6,15 +6,15 @@ Copyright (c) 2009-2014 Bitcoin Developers
 
 Setup
 ---------------------
-[Bitcoin Core](http://bitcoin.org/en/download) is the original Bitcoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Bitcoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more. Thankfully you only have to do this once. If you would like the process to go faster you can [download the blockchain directly](https://bitcointalk.org/index.php?topic=145386.0).
+[Dogecoin Core](http://bitcoin.org/en/download) is the original Dogecoin client and it builds the backbone of the network. However, it downloads and stores the entire history of Dogecoin transactions (which is currently several GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more. Thankfully you only have to do this once. If you would like the process to go faster you can [download the blockchain directly](https://bitcointalk.org/index.php?topic=145386.0).
 
 Running
 ---------------------
-The following are some helpful notes on how to run Bitcoin on your native platform. 
+The following are some helpful notes on how to run Dogecoin on your native platform. 
 
 ### Unix
 
-You need the Qt4 run-time libraries to run Bitcoin-Qt. On Debian or Ubuntu:
+You need the Qt4 run-time libraries to run Dogecoin-Qt. On Debian or Ubuntu:
 
 	sudo apt-get install libqtgui4
 
@@ -31,18 +31,18 @@ Unpack the files into a directory, and then run bitcoin-qt.exe.
 
 ### OSX
 
-Drag Bitcoin-Qt to your applications folder, and then run Bitcoin-Qt.
+Drag Dogecoin-Qt to your applications folder, and then run Dogecoin-Qt.
 
 ### Need Help?
 
-* See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
+* See the documentation at the [Dogecoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
 for help and more information.
 * Ask for help on [#bitcoin](http://webchat.freenode.net?channels=bitcoin) on Freenode. If you don't have an IRC client use [webchat here](http://webchat.freenode.net?channels=bitcoin).
 * Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
 
 Building
 ---------------------
-The following are developer notes on how to build Bitcoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
+The following are developer notes on how to build Dogecoin on your native platform. They are not complete guides, but include notes on the necessary libraries, compile flags, etc.
 
 - [OSX Build Notes](build-osx.md)
 - [Unix Build Notes](build-unix.md)
@@ -50,7 +50,7 @@ The following are developer notes on how to build Bitcoin on your native platfor
 
 Development
 ---------------------
-The Bitcoin repo's [root README](https://github.com/bitcoin/bitcoin/blob/master/README.md) contains relevant information on the development process and automated testing.
+The Dogecoin repo's [root README](https://github.com/bitcoin/bitcoin/blob/master/README.md) contains relevant information on the development process and automated testing.
 
 - [Coding Guidelines](coding.md)
 - [Multiwallet Qt Development](multiwallet-qt.md)

--- a/doc/README.md
+++ b/doc/README.md
@@ -14,24 +14,24 @@ The following are some helpful notes on how to run Dogecoin on your native platf
 
 ### Unix
 
-You need the Qt4 run-time libraries to run Dogecoin-Qt. On Debian or Ubuntu:
+You need the Qt4 run-time libraries to run Inutoshi-Qt. On Debian or Ubuntu:
 
 	sudo apt-get install libqtgui4
 
 Unpack the files into a directory and run:
 
-- bin/32/dogecoin-qt (GUI, 32-bit) or bin/32/dogecoind (headless, 32-bit)
-- bin/64/dogecoin-qt (GUI, 64-bit) or bin/64/dogecoind (headless, 64-bit)
+- bin/32/inutoshi-qt (GUI, 32-bit) or bin/32/inutoshid (headless, 32-bit)
+- bin/64/inutoshi-qt (GUI, 64-bit) or bin/64/inutoshid (headless, 64-bit)
 
 
 
 ### Windows
 
-Unpack the files into a directory, and then run dogecoin-qt.exe.
+Unpack the files into a directory, and then run inutoshi-qt.exe.
 
 ### OSX
 
-Drag Dogecoin-Qt to your applications folder, and then run Dogecoin-Qt.
+Drag Inutoshi-Qt to your applications folder, and then run Inutoshi-Qt.
 
 ### Need Help?
 

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Bitcoin 0.9.0rc1 BETA
+Dogecoin 0.9.0rc1 BETA
 
 Copyright (c) 2009-2014 Bitcoin Core Developers
 
@@ -11,7 +11,7 @@ cryptographic software written by Eric Young (eay@cryptsoft.com).
 
 Intro
 -----
-Bitcoin is a free open source peer-to-peer electronic cash system that is
+Dogecoin is a free open source peer-to-peer electronic cash system that is
 completely decentralized, without the need for a central server or trusted
 parties.  Users hold the crypto keys to their own money and transact directly
 with each other, with the help of a P2P network to check for double-spending.
@@ -21,11 +21,11 @@ Setup
 -----
 Unpack the files into a directory and run bitcoin-qt.exe.
 
-Bitcoin Core is the original Bitcoin client and it builds the backbone of the network.
-However, it downloads and stores the entire history of Bitcoin transactions;
+Dogecoin Core is the original Dogecoin client and it builds the backbone of the network.
+However, it downloads and stores the entire history of Dogecoin transactions;
 depending on the speed of your computer and network connection, the synchronization
 process can take anywhere from a few hours to a day or more.
 
-See the bitcoin wiki at:
+See the Dogecoin wiki at:
   https://en.bitcoin.it/wiki/Main_Page
 for more help and information.

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -19,7 +19,7 @@ with each other, with the help of a P2P network to check for double-spending.
 
 Setup
 -----
-Unpack the files into a directory and run bitcoin-qt.exe.
+Unpack the files into a directory and run dogecoin-qt.exe.
 
 Dogecoin Core is the original Dogecoin client and it builds the backbone of the network.
 However, it downloads and stores the entire history of Dogecoin transactions;
@@ -27,5 +27,5 @@ depending on the speed of your computer and network connection, the synchronizat
 process can take anywhere from a few hours to a day or more.
 
 See the Dogecoin wiki at:
-  https://en.bitcoin.it/wiki/Main_Page
+  http://dogeco.in/
 for more help and information.

--- a/doc/README_windows.txt
+++ b/doc/README_windows.txt
@@ -1,4 +1,4 @@
-Dogecoin 0.9.0rc1 BETA
+Inutoshi 0.9.0rc1 BETA
 
 Copyright (c) 2009-2014 Bitcoin Core Developers
 
@@ -11,7 +11,7 @@ cryptographic software written by Eric Young (eay@cryptsoft.com).
 
 Intro
 -----
-Dogecoin is a free open source peer-to-peer electronic cash system that is
+Inutoshi is a free open source peer-to-peer electronic cash system that is
 completely decentralized, without the need for a central server or trusted
 parties.  Users hold the crypto keys to their own money and transact directly
 with each other, with the help of a P2P network to check for double-spending.
@@ -21,10 +21,10 @@ Setup
 -----
 Unpack the files into a directory and run dogecoin-qt.exe.
 
-Dogecoin Core is the original Dogecoin client and it builds the backbone of the network.
+Inutoshi is the a Dogecoin client based on the Bitcoin client, and it builds the
+backbone of the network.
 However, it downloads and stores the entire history of Dogecoin transactions;
-depending on the speed of your computer and network connection, the synchronization
-process can take anywhere from a few hours to a day or more.
+depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
 See the Dogecoin wiki at:
   http://dogeco.in/

--- a/doc/assets-attribution.md
+++ b/doc/assets-attribution.md
@@ -97,8 +97,8 @@ Jonas Schnelli
 * License: MIT
 
 ### Assets Used
-	src/qt/res/icons/bitcoin.icns, src/qt/res/src/bitcoin.svg,
-	src/qt/res/src/bitcoin.ico, src/qt/res/src/bitcoin.png,
-	src/qt/res/src/bitcoin_testnet.png, docs/bitcoin_logo_doxygen.png,
+	src/qt/res/icons/dogecoin.icns, src/qt/res/src/dogecoin.svg,
+	src/qt/res/src/dogecoin.ico, src/qt/res/src/dogecoin.png,
+	src/qt/res/src/dogecoin_testnet.png, docs/dogecoin_logo_doxygen.png,
 	src/qt/res/icons/toolbar.png, src/qt/res/icons/toolbar_testnet.png,
 	src/qt/res/images/splash.png, src/qt/res/images/splash_testnet.png

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -72,7 +72,7 @@ MSYS shell:
 	mkdir miniupnpc
 	cp *.h miniupnpc/
 
-Bitcoin
+Dogecoin
 -------
 MSYS shell:
 

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -76,7 +76,7 @@ Dogecoin
 -------
 MSYS shell:
 
-	cd \bitcoin
+	cd \dogecoin
 	sh autogen.sh
 	sh configure
 	mingw32-make

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -80,4 +80,4 @@ MSYS shell:
 	sh autogen.sh
 	sh configure
 	mingw32-make
-	strip bitcoind.exe
+	strip dogecoind.exe

--- a/doc/build-msw.md
+++ b/doc/build-msw.md
@@ -76,8 +76,8 @@ Dogecoin
 -------
 MSYS shell:
 
-	cd \dogecoin
+	cd \inutoshi
 	sh autogen.sh
 	sh configure
 	mingw32-make
-	strip dogecoind.exe
+	strip inutoshid.exe

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,6 +1,6 @@
 Mac OS X Build Instructions and Notes
 ====================================
-This guide will show you how to build bitcoind(headless client) for OSX.
+This guide will show you how to build dogecoind(headless client) for OSX.
 
 Notes
 -----
@@ -52,14 +52,14 @@ Optional: install Qt4
 
     sudo port install qt4-mac qrencode protobuf-cpp
 
-### Building `bitcoind`
+### Building `dogecoind`
 
 1. Clone the github tree to get the source code and go into the directory.
 
-        git clone git@github.com:bitcoin/bitcoin.git bitcoin
-        cd bitcoin
+        git clone git@github.com:dogecoin/dogecoin.git dogecoin
+        cd dogecoin
 
-2.  Build bitcoind (and Bitcoin-Qt, if configured):
+2.  Build dogecoind (and Dogecoin-Qt, if configured):
 
         ./autogen.sh
         ./configure
@@ -88,14 +88,14 @@ If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
 
 Rerunning "openssl version" should now return the correct version.
 
-### Building `bitcoind`
+### Building `dogecoind`
 
 1. Clone the github tree to get the source code and go into the directory.
 
-        git clone https://github.com/bitcoin/bitcoin.git
-        cd bitcoin
+        git clone https://github.com/dogecoin/dogecoin.git
+        cd dogecoin
 
-2.  Build bitcoind:
+2.  Build dogecoind:
 
         ./autogen.sh
         ./configure
@@ -107,11 +107,11 @@ Rerunning "openssl version" should now return the correct version.
 
 Creating a release build
 ------------------------
-You can ignore this section if you are building `bitcoind` for your own use.
+You can ignore this section if you are building `dogecoind` for your own use.
 
-bitcoind/bitcoin-cli binaries are not included in the Bitcoin-Qt.app bundle.
+dogecoind/dogecoin-cli binaries are not included in the Dogecoin-Qt.app bundle.
 
-If you are building `bitcoind` or `Bitcoin-Qt` for others, your build machine should be set up
+If you are building `dogecoind` or `Dogecoin-Qt` for others, your build machine should be set up
 as follows for maximum compatibility:
 
 All dependencies should be compiled with these flags:
@@ -132,29 +132,29 @@ As of December 2012, the `boost` port does not obey `macosx_deployment_target`.
 Download `http://gavinandresen-bitcoin.s3.amazonaws.com/boost_macports_fix.zip`
 for a fix.
 
-Once dependencies are compiled, see release-process.md for how the Bitcoin-Qt.app
+Once dependencies are compiled, see release-process.md for how the Dogecoin-Qt.app
 bundle is packaged and signed to create the .dmg disk image that is distributed.
 
 Running
 -------
 
-It's now available at `./bitcoind`, provided that you are still in the `src`
+It's now available at `./dogecoind`, provided that you are still in the `src`
 directory. We have to first create the RPC configuration file, though.
 
-Run `./bitcoind` to get the filename where it should be put, or just try these
+Run `./dogecoind` to get the filename where it should be put, or just try these
 commands:
 
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+    echo -e "rpcuser=dogecoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Dogecoin/dogecoin.conf"
+    chmod 600 "/Users/${USER}/Library/Application Support/Dogecoin/dogecoin.conf"
 
 When next you run it, it will start downloading the blockchain, but it won't
 output anything while it's doing this. This process may take several hours;
 you can monitor its process by looking at the debug.log file, like this:
 
-    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+    tail -f $HOME/Library/Application\ Support/Dogecoin/debug.log
 
 Other commands:
 
-    ./bitcoind -daemon # to start the bitcoin daemon.
-    ./bitcoin-cli --help  # for a list of command-line options.
-    ./bitcoin-cli help    # When the daemon is running, to get a list of RPC commands
+    ./dogecoind -daemon # to start the dogecoin daemon.
+    ./dogecoin-cli --help  # for a list of command-line options.
+    ./dogecoin-cli help    # When the daemon is running, to get a list of RPC commands

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,6 +1,6 @@
 Mac OS X Build Instructions and Notes
 ====================================
-This guide will show you how to build dogecoind(headless client) for OSX.
+This guide will show you how to build inutoshid(headless client) for OSX.
 
 Notes
 -----
@@ -52,14 +52,14 @@ Optional: install Qt4
 
     sudo port install qt4-mac qrencode protobuf-cpp
 
-### Building `dogecoind`
+### Building `inutoshid`
 
 1. Clone the github tree to get the source code and go into the directory.
 
         git clone git@github.com:dogecoin/dogecoin.git dogecoin
         cd dogecoin
 
-2.  Build dogecoind (and Dogecoin-Qt, if configured):
+2.  Build inutoshid (and Inutoshi-Qt, if configured):
 
         ./autogen.sh
         ./configure
@@ -88,14 +88,14 @@ If not, you can ensure that the Homebrew OpenSSL is correctly linked by running
 
 Rerunning "openssl version" should now return the correct version.
 
-### Building `dogecoind`
+### Building `inutoshid`
 
 1. Clone the github tree to get the source code and go into the directory.
 
         git clone https://github.com/dogecoin/dogecoin.git
         cd dogecoin
 
-2.  Build dogecoind:
+2.  Build inutoshid:
 
         ./autogen.sh
         ./configure
@@ -107,11 +107,11 @@ Rerunning "openssl version" should now return the correct version.
 
 Creating a release build
 ------------------------
-You can ignore this section if you are building `dogecoind` for your own use.
+You can ignore this section if you are building `inutoshid` for your own use.
 
-dogecoind/dogecoin-cli binaries are not included in the Dogecoin-Qt.app bundle.
+inutoshid/dogecoin-cli binaries are not included in the Inutoshi-Qt.app bundle.
 
-If you are building `dogecoind` or `Dogecoin-Qt` for others, your build machine should be set up
+If you are building `inutoshid` or `Inutoshi-Qt` for others, your build machine should be set up
 as follows for maximum compatibility:
 
 All dependencies should be compiled with these flags:
@@ -132,29 +132,29 @@ As of December 2012, the `boost` port does not obey `macosx_deployment_target`.
 Download `http://gavinandresen-bitcoin.s3.amazonaws.com/boost_macports_fix.zip`
 for a fix.
 
-Once dependencies are compiled, see release-process.md for how the Dogecoin-Qt.app
+Once dependencies are compiled, see release-process.md for how the Inutoshi-Qt.app
 bundle is packaged and signed to create the .dmg disk image that is distributed.
 
 Running
 -------
 
-It's now available at `./dogecoind`, provided that you are still in the `src`
+It's now available at `./inutoshid`, provided that you are still in the `src`
 directory. We have to first create the RPC configuration file, though.
 
-Run `./dogecoind` to get the filename where it should be put, or just try these
+Run `./inutoshid` to get the filename where it should be put, or just try these
 commands:
 
-    echo -e "rpcuser=dogecoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Dogecoin/dogecoin.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/Dogecoin/dogecoin.conf"
+    echo -e "rpcuser=inutoshirpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Inutoshi/inutoshi.conf"
+    chmod 600 "/Users/${USER}/Library/Application Support/Inutoshi/inutoshi.conf"
 
 When next you run it, it will start downloading the blockchain, but it won't
 output anything while it's doing this. This process may take several hours;
 you can monitor its process by looking at the debug.log file, like this:
 
-    tail -f $HOME/Library/Application\ Support/Dogecoin/debug.log
+    tail -f $HOME/Library/Application\ Support/Inutoshi/debug.log
 
 Other commands:
 
-    ./dogecoind -daemon # to start the dogecoin daemon.
+    ./inutoshid -daemon # to start the dogecoin daemon.
     ./dogecoin-cli --help  # for a list of command-line options.
     ./dogecoin-cli help    # When the daemon is running, to get a list of RPC commands

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,6 +1,6 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Bitcoin in Unix. 
+Some notes on how to build Dogecoin in Unix. 
 
 To Build
 ---------------------
@@ -101,7 +101,7 @@ Optional:
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------
 
-If you want to build Bitcoin-Qt, make sure that the required packages for Qt development
+If you want to build Dogecoin-Qt, make sure that the required packages for Qt development
 are installed. Either Qt 4 or Qt 5 are necessary to build the GUI.
 If both Qt 4 and Qt 5 are installed, Qt 4 will be used. Pass `--with-gui=qt5` to configure to choose Qt5.
 To build without GUI pass `--without-gui`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,7 +9,7 @@ To Build
 	./configure
 	make
 
-This will build bitcoin-qt as well if the dependencies are met.
+This will build dogecoin-qt as well if the dependencies are met.
 
 Dependencies
 ---------------------
@@ -17,7 +17,7 @@ Dependencies
  Library     | Purpose          | Description
  ------------|------------------|----------------------
  libssl      | SSL Support      | Secure communications
- libdb4.8    | Berkeley DB      | Wallet storage
+ libdb5.1    | Berkeley DB      | Wallet storage
  libboost    | Boost            | C++ Library
  miniupnpc   | UPnP Support     | Optional firewall-jumping support
  qt          | GUI              | GUI toolkit
@@ -45,7 +45,7 @@ Licenses of statically linked libraries:
 - Versions used in this release:
 -  GCC           4.3.3
 -  OpenSSL       1.0.1c
--  Berkeley DB   4.8.30.NC
+-  Berkeley DB   5.1
 -  Boost         1.55
 -  miniupnpc     1.6
 -  qt            4.8.3
@@ -64,7 +64,7 @@ for Ubuntu 12.04 and later:
 
 	sudo apt-get install libboost-all-dev
 
- db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
+ db5.1 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
  You can add the repository using the following command:
 
         sudo add-apt-repository ppa:bitcoin/bitcoin
@@ -78,7 +78,6 @@ for Ubuntu 13.10:
 	remove libboost1.54-all-dev and install libboost1.53-all-dev instead.
 
 for Debian 7 (Wheezy) and later:
- The oldstable repository contains db4.8 packages.
  Add the following line to /etc/apt/sources.list,
  replacing [mirror] with any official debian mirror.
 
@@ -90,8 +89,8 @@ To enable the change run
 
 for other Ubuntu & Debian:
 
-	sudo apt-get install libdb4.8-dev
-	sudo apt-get install libdb4.8++-dev
+	sudo apt-get install libdb5.1-dev
+	sudo apt-get install libdb5.1++-dev
 	sudo apt-get install libboost1.55-all-dev
 
 Optional:
@@ -118,12 +117,12 @@ libqrencode (optional) can be installed with:
 
     sudo apt-get install libqrencode-dev
 
-Once these are installed, they will be found by configure and a bitcoin-qt executable will be
+Once these are installed, they will be found by configure and a dogecoin-qt executable will be
 built by default.
 
 Notes
 -----
-The release is built with GCC and then "strip bitcoind" to strip the debug
+The release is built with GCC and then "strip dogecoind" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
@@ -138,7 +137,7 @@ miniupnpc
 
 Berkeley DB
 -----------
-You need Berkeley DB 4.8.  If you have to build Berkeley DB yourself:
+You need Berkeley DB 5.1.  If you have to build Berkeley DB yourself:
 
 	cd build_unix/
 	../dist/configure --enable-cxx
@@ -181,7 +180,7 @@ Hardening enables the following features:
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-    	scanelf -e ./bitcoin
+    	scanelf -e ./dogecoin
 
     The output should contain:
      TYPE
@@ -195,7 +194,7 @@ Hardening enables the following features:
     executable without the non-executable stack protection.
 
     To verify that the stack is non-executable after compiling use:
-    `scanelf -e ./bitcoin`
+    `scanelf -e ./dogecoin`
 
     the output should contain:
 	STK/REL/PTL
@@ -210,7 +209,7 @@ disable-wallet mode with:
 
     ./configure --disable-wallet
 
-In this case there is no dependency on Berkeley DB 4.8.
+In this case there is no dependency on Berkeley DB 5.1.
 
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call not `getwork`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -17,7 +17,7 @@ Dependencies
  Library     | Purpose          | Description
  ------------|------------------|----------------------
  libssl      | SSL Support      | Secure communications
- libdb5.1    | Berkeley DB      | Wallet storage
+ libdb4.8    | Berkeley DB      | Wallet storage
  libboost    | Boost            | C++ Library
  miniupnpc   | UPnP Support     | Optional firewall-jumping support
  qt          | GUI              | GUI toolkit
@@ -45,7 +45,7 @@ Licenses of statically linked libraries:
 - Versions used in this release:
 -  GCC           4.3.3
 -  OpenSSL       1.0.1c
--  Berkeley DB   5.1
+-  Berkeley DB   4.8
 -  Boost         1.55
 -  miniupnpc     1.6
 -  qt            4.8.3
@@ -64,13 +64,13 @@ for Ubuntu 12.04 and later:
 
 	sudo apt-get install libboost-all-dev
 
- db5.1 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
+ db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
  You can add the repository using the following command:
 
         sudo add-apt-repository ppa:bitcoin/bitcoin
         sudo apt-get update
 
- Ubuntu 12.04 and later have packages for libdb5.1-dev and libdb5.1++-dev,
+ Ubuntu 12.04 and later have packages for libdb4.8-dev and libdb4.8++-dev,
  but using these will break binary wallet compatibility, and is not recommended.
 
 for Ubuntu 13.10:
@@ -89,8 +89,8 @@ To enable the change run
 
 for other Ubuntu & Debian:
 
-	sudo apt-get install libdb5.1-dev
-	sudo apt-get install libdb5.1++-dev
+	sudo apt-get install libdb4.8-dev
+	sudo apt-get install libdb4.8++-dev
 	sudo apt-get install libboost1.55-all-dev
 
 Optional:
@@ -137,7 +137,7 @@ miniupnpc
 
 Berkeley DB
 -----------
-You need Berkeley DB 5.1.  If you have to build Berkeley DB yourself:
+You need Berkeley DB 4.8.  If you have to build Berkeley DB yourself:
 
 	cd build_unix/
 	../dist/configure --enable-cxx
@@ -209,7 +209,7 @@ disable-wallet mode with:
 
     ./configure --disable-wallet
 
-In this case there is no dependency on Berkeley DB 5.1.
+In this case there is no dependency on Berkeley DB 4.8.
 
 Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
 call not `getwork`.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,6 +1,6 @@
 UNIX BUILD NOTES
 ====================
-Some notes on how to build Dogecoin in Unix. 
+Some notes on how to build Inutoshi in Unix. 
 
 To Build
 ---------------------
@@ -9,7 +9,7 @@ To Build
 	./configure
 	make
 
-This will build dogecoin-qt as well if the dependencies are met.
+This will build inutoshi-qt as well if the dependencies are met.
 
 Dependencies
 ---------------------
@@ -100,7 +100,7 @@ Optional:
 Dependencies for the GUI: Ubuntu & Debian
 -----------------------------------------
 
-If you want to build Dogecoin-Qt, make sure that the required packages for Qt development
+If you want to build Inutoshi-Qt, make sure that the required packages for Qt development
 are installed. Either Qt 4 or Qt 5 are necessary to build the GUI.
 If both Qt 4 and Qt 5 are installed, Qt 4 will be used. Pass `--with-gui=qt5` to configure to choose Qt5.
 To build without GUI pass `--without-gui`.
@@ -117,12 +117,12 @@ libqrencode (optional) can be installed with:
 
     sudo apt-get install libqrencode-dev
 
-Once these are installed, they will be found by configure and a dogecoin-qt executable will be
+Once these are installed, they will be found by configure and a inutoshi-qt executable will be
 built by default.
 
 Notes
 -----
-The release is built with GCC and then "strip dogecoind" to strip the debug
+The release is built with GCC and then "strip inutoshid" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
@@ -180,7 +180,7 @@ Hardening enables the following features:
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-    	scanelf -e ./dogecoin
+    	scanelf -e ./inutoshi
 
     The output should contain:
      TYPE
@@ -194,7 +194,7 @@ Hardening enables the following features:
     executable without the non-executable stack protection.
 
     To verify that the stack is non-executable after compiling use:
-    `scanelf -e ./dogecoin`
+    `scanelf -e ./inutoshi`
 
     the output should contain:
 	STK/REL/PTL

--- a/doc/coding.md
+++ b/doc/coding.md
@@ -75,7 +75,7 @@ Threads
 
 - ThreadMapPort : Universal plug-and-play startup/shutdown
 
-- ThreadSocketHandler : Sends/Receives data from peers on port 8333.
+- ThreadSocketHandler : Sends/Receives data from peers on port 22556.
 
 - ThreadOpenAddedConnections : Opens network connections to added nodes.
 
@@ -87,7 +87,7 @@ Threads
 
 - ThreadFlushWalletDB : Close the wallet.dat file if it hasn't been used in 500ms.
 
-- ThreadRPCServer : Remote procedure call handler, listens on port 8332 for connections and services them.
+- ThreadRPCServer : Remote procedure call handler, listens on port 22555 for connections and services them.
 
 - BitcoinMiner : Generates bitcoins (if wallet is enabled).
 

--- a/doc/multiwallet-qt.md
+++ b/doc/multiwallet-qt.md
@@ -1,7 +1,7 @@
 Multiwallet Qt Development and Integration Strategy
 ===================================================
 
-In order to support loading of multiple wallets in bitcoin-qt, a few changes in the UI architecture will be needed.
+In order to support loading of multiple wallets in dogecoin-qt, a few changes in the UI architecture will be needed.
 Fortunately, only four of the files in the existing project are affected by this change.
 
 Two new classes have been implemented in two new .h/.cpp file pairs, with much of the functionality that was previously
@@ -12,7 +12,7 @@ some major retrofitting.
 
 Only requiring some minor changes is bitcoin.cpp.
 
-Finally, two new headers and source files will have to be added to bitcoin-qt.pro.
+Finally, two new headers and source files will have to be added to dogecoin-qt.pro.
 
 Changes to class BitcoinGUI
 ---------------------------
@@ -32,7 +32,7 @@ merges while reducing the risk of breaking top-level stuff.
 
 Changes to bitcoin.cpp
 ----------------------
-bitcoin.cpp is the entry point into bitcoin-qt, and as such, will require some minor modifications to provide hooks for
+bitcoin.cpp is the entry point into dogecoin-qt, and as such, will require some minor modifications to provide hooks for
 multiple wallet support. Most importantly will be the way it instantiates WalletModels and passes them to the
 singleton BitcoinGUI instance called window. Formerly, BitcoinGUI kept a pointer to a single instance of a WalletModel.
 The initial change required is very simple: rather than calling `window.setWalletModel(&walletModel);` we perform the

--- a/doc/multiwallet-qt.md
+++ b/doc/multiwallet-qt.md
@@ -1,7 +1,7 @@
 Multiwallet Qt Development and Integration Strategy
 ===================================================
 
-In order to support loading of multiple wallets in dogecoin-qt, a few changes in the UI architecture will be needed.
+In order to support loading of multiple wallets in inutoshi-qt, a few changes in the UI architecture will be needed.
 Fortunately, only four of the files in the existing project are affected by this change.
 
 Two new classes have been implemented in two new .h/.cpp file pairs, with much of the functionality that was previously
@@ -12,7 +12,7 @@ some major retrofitting.
 
 Only requiring some minor changes is bitcoin.cpp.
 
-Finally, two new headers and source files will have to be added to dogecoin-qt.pro.
+Finally, two new headers and source files will have to be added to inutoshi-qt.pro.
 
 Changes to class BitcoinGUI
 ---------------------------
@@ -32,7 +32,7 @@ merges while reducing the risk of breaking top-level stuff.
 
 Changes to bitcoin.cpp
 ----------------------
-bitcoin.cpp is the entry point into dogecoin-qt, and as such, will require some minor modifications to provide hooks for
+bitcoin.cpp is the entry point into inutoshi-qt, and as such, will require some minor modifications to provide hooks for
 multiple wallet support. Most importantly will be the way it instantiates WalletModels and passes them to the
 singleton BitcoinGUI instance called window. Formerly, BitcoinGUI kept a pointer to a single instance of a WalletModel.
 The initial change required is very simple: rather than calling `window.setWalletModel(&walletModel);` we perform the

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -112,9 +112,9 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 	export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
 	T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
         export CODESIGNARGS='--keychain ...path_to_keychain --sign "Developer ID Application: BITCOIN FOUNDATION, INC., THE"'
-	python2.7 contrib/macdeploy/macdeployqtplus Bitcoin-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
+	python2.7 contrib/macdeploy/macdeployqtplus Dogecoin-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
 
- Build output expected: Bitcoin-Qt.dmg
+ Build output expected: Dogecoin-Qt.dmg
 
 ###Next steps:
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -69,37 +69,37 @@ Release Process
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
 	pushd build/out
-	zip -r bitcoin-${VERSION}-linux-gitian.zip *
-	mv bitcoin-${VERSION}-linux-gitian.zip ../../../
+	zip -r dogecoin-${VERSION}-linux-gitian.zip *
+	mv dogecoin-${VERSION}-linux-gitian.zip ../../../
 	popd
 	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION}-win --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
 	pushd build/out
-	zip -r bitcoin-${VERSION}-win-gitian.zip *
-	mv bitcoin-${VERSION}-win-gitian.zip ../../../
+	zip -r dogecoin-${VERSION}-win-gitian.zip *
+	mv dogecoin-${VERSION}-win-gitian.zip ../../../
 	popd
 	popd
 
   Build output expected:
 
-  1. linux 32-bit and 64-bit binaries + source (bitcoin-${VERSION}-linux-gitian.zip)
-  2. windows 32-bit and 64-bit binaries + installer + source (bitcoin-${VERSION}-win-gitian.zip)
+  1. linux 32-bit and 64-bit binaries + source (dogecoin-${VERSION}-linux-gitian.zip)
+  2. windows 32-bit and 64-bit binaries + installer + source (dogecoin-${VERSION}-win-gitian.zip)
   3. Gitian signatures (in gitian.sigs/${VERSION}[-win]/(your gitian key)/
 
 repackage gitian builds for release as stand-alone zip/tar/installer exe
 
 **Linux .tar.gz:**
 
-	unzip bitcoin-${VERSION}-linux-gitian.zip -d bitcoin-${VERSION}-linux
-	tar czvf bitcoin-${VERSION}-linux.tar.gz bitcoin-${VERSION}-linux
-	rm -rf bitcoin-${VERSION}-linux
+	unzip dogecoin-${VERSION}-linux-gitian.zip -d dogecoin-${VERSION}-linux
+	tar czvf dogecoin-${VERSION}-linux.tar.gz dogecoin-${VERSION}-linux
+	rm -rf dogecoin-${VERSION}-linux
 
 **Windows .zip and setup.exe:**
 
-	unzip bitcoin-${VERSION}-win-gitian.zip -d bitcoin-${VERSION}-win
-	mv bitcoin-${VERSION}-win/bitcoin-*-setup.exe .
-	zip -r bitcoin-${VERSION}-win.zip bitcoin-${VERSION}-win
-	rm -rf bitcoin-${VERSION}-win
+	unzip dogecoin-${VERSION}-win-gitian.zip -d dogecoin-${VERSION}-win
+	mv dogecoin-${VERSION}-win/bitcoin-*-setup.exe .
+	zip -r dogecoin-${VERSION}-win.zip dogecoin-${VERSION}-win
+	rm -rf dogecoin-${VERSION}-win
 
 **Perform Mac build:**
 
@@ -152,29 +152,29 @@ Commit your signature to gitian.sigs:
 From a directory containing bitcoin source, gitian.sigs and gitian zips
 
 	export VERSION=(new version, e.g. 0.8.0)
-	mkdir bitcoin-${VERSION}-linux-gitian
-	pushd bitcoin-${VERSION}-linux-gitian
-	unzip ../bitcoin-${VERSION}-linux-gitian.zip
+	mkdir dogecoin-${VERSION}-linux-gitian
+	pushd dogecoin-${VERSION}-linux-gitian
+	unzip ../dogecoin-${VERSION}-linux-gitian.zip
 	mkdir gitian
 	cp ../bitcoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}/); do
 	 cp ../gitian.sigs/${VERSION}/${signer}/bitcoin-build.assert ./gitian/${signer}-build.assert
 	 cp ../gitian.sigs/${VERSION}/${signer}/bitcoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r bitcoin-${VERSION}-linux-gitian.zip *
-	cp bitcoin-${VERSION}-linux-gitian.zip ../
+	zip -r dogecoin-${VERSION}-linux-gitian.zip *
+	cp dogecoin-${VERSION}-linux-gitian.zip ../
 	popd
-	mkdir bitcoin-${VERSION}-win-gitian
-	pushd bitcoin-${VERSION}-win-gitian
-	unzip ../bitcoin-${VERSION}-win-gitian.zip
+	mkdir dogecoin-${VERSION}-win-gitian
+	pushd dogecoin-${VERSION}-win-gitian
+	unzip ../dogecoin-${VERSION}-win-gitian.zip
 	mkdir gitian
 	cp ../bitcoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}-win/); do
 	 cp ../gitian.sigs/${VERSION}-win/${signer}/bitcoin-build.assert ./gitian/${signer}-build.assert
 	 cp ../gitian.sigs/${VERSION}-win/${signer}/bitcoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r bitcoin-${VERSION}-win-gitian.zip *
-	cp bitcoin-${VERSION}-win-gitian.zip ../
+	zip -r dogecoin-${VERSION}-win-gitian.zip *
+	cp dogecoin-${VERSION}-win-gitian.zip ../
 	popd
 
 - Upload gitian zips to SourceForge

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -27,11 +27,11 @@ Release Process
 
 ##perform gitian builds
 
- From a directory containing the bitcoin source, gitian-builder and gitian.sigs
+ From a directory containing the dogecoin source, gitian-builder and gitian.sigs
   
 	export SIGNER=(your gitian key, ie bluematt, sipa, etc)
 	export VERSION=(new version, e.g. 0.8.0)
-	pushd ./bitcoin
+	pushd ./dogecoin
 	git checkout v${VERSION}
 	popd
 	pushd ./gitian-builder
@@ -51,29 +51,29 @@ Release Process
 	wget 'https://download.qt-project.org/official_releases/qt/5.2/5.2.0/single/qt-everywhere-opensource-src-5.2.0.tar.gz'
 	wget 'https://protobuf.googlecode.com/files/protobuf-2.5.0.tar.bz2'
 	cd ..
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-linux.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/boost-linux.yml
 	mv build/out/boost-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-linux.yml
-	mv build/out/bitcoin-deps-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/deps-linux.yml
+	mv build/out/dogecoin-deps-*.zip inputs/
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/boost-win.yml
 	mv build/out/boost-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win.yml
-	mv build/out/bitcoin-deps-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/deps-win.yml
+	mv build/out/dogecoin-deps-*.zip inputs/
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/qt-win.yml
 	mv build/out/qt-*.zip inputs/
-	./bin/gbuild ../bitcoin/contrib/gitian-descriptors/protobuf-win.yml
+	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/protobuf-win.yml
 	mv build/out/protobuf-*.zip inputs/
 
- Build bitcoind and bitcoin-qt on Linux32, Linux64, and Win32:
+ Build dogecoind and dogecoin-qt on Linux32, Linux64, and Win32:
   
-	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gbuild --commit bitcoin=v${VERSION} ../dogecoin/contrib/gitian-descriptors/gitian-linux.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../dogecoin/contrib/gitian-descriptors/gitian-linux.yml
 	pushd build/out
 	zip -r dogecoin-${VERSION}-linux-gitian.zip *
 	mv dogecoin-${VERSION}-linux-gitian.zip ../../../
 	popd
-	./bin/gbuild --commit bitcoin=v${VERSION} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	./bin/gsign --signer $SIGNER --release ${VERSION}-win --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+	./bin/gbuild --commit bitcoin=v${VERSION} ../dogecoin/contrib/gitian-descriptors/gitian-win.yml
+	./bin/gsign --signer $SIGNER --release ${VERSION}-win --destination ../gitian.sigs/ ../dogecoin/contrib/gitian-descriptors/gitian-win.yml
 	pushd build/out
 	zip -r dogecoin-${VERSION}-win-gitian.zip *
 	mv dogecoin-${VERSION}-win-gitian.zip ../../../
@@ -97,7 +97,7 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 **Windows .zip and setup.exe:**
 
 	unzip dogecoin-${VERSION}-win-gitian.zip -d dogecoin-${VERSION}-win
-	mv dogecoin-${VERSION}-win/bitcoin-*-setup.exe .
+	mv dogecoin-${VERSION}-win/dogecoin-*-setup.exe .
 	zip -r dogecoin-${VERSION}-win.zip dogecoin-${VERSION}-win
 	rm -rf dogecoin-${VERSION}-win
 
@@ -111,7 +111,7 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 	make
 	export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
 	T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
-        export CODESIGNARGS='--keychain ...path_to_keychain --sign "Developer ID Application: BITCOIN FOUNDATION, INC., THE"'
+        export CODESIGNARGS='--keychain ...path_to_keychain --sign "Developer ID Application: DOGECOIN FOUNDATION, INC., THE"'
 	python2.7 contrib/macdeploy/macdeployqtplus Dogecoin-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
 
  Build output expected: Dogecoin-Qt.dmg
@@ -125,11 +125,9 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 
 * create SHA256SUMS for builds, and PGP-sign it
 
-* update bitcoin.org version
+* update dogecoin.com version
   make sure all OS download links go to the right versions
   
-* update download sizes on bitcoin.org/_templates/download.html
-
 * update forum version
 
 * update wiki download links
@@ -152,41 +150,39 @@ Commit your signature to gitian.sigs:
 From a directory containing bitcoin source, gitian.sigs and gitian zips
 
 	export VERSION=(new version, e.g. 0.8.0)
-	mkdir dogecoin-${VERSION}-linux-gitian
-	pushd dogecoin-${VERSION}-linux-gitian
+	mkdir bitcoin-${VERSION}-linux-gitian
+	pushd bitcoin-${VERSION}-linux-gitian
 	unzip ../dogecoin-${VERSION}-linux-gitian.zip
 	mkdir gitian
-	cp ../bitcoin/contrib/gitian-downloader/*.pgp ./gitian/
+	cp ../dogecoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}/); do
-	 cp ../gitian.sigs/${VERSION}/${signer}/bitcoin-build.assert ./gitian/${signer}-build.assert
-	 cp ../gitian.sigs/${VERSION}/${signer}/bitcoin-build.assert.sig ./gitian/${signer}-build.assert.sig
+	 cp ../gitian.sigs/${VERSION}/${signer}/dogecoin-build.assert ./gitian/${signer}-build.assert
+	 cp ../gitian.sigs/${VERSION}/${signer}/dogecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r dogecoin-${VERSION}-linux-gitian.zip *
-	cp dogecoin-${VERSION}-linux-gitian.zip ../
+	zip -r bitcoin-${VERSION}-linux-gitian.zip *
+	cp bitcoin-${VERSION}-linux-gitian.zip ../
 	popd
-	mkdir dogecoin-${VERSION}-win-gitian
-	pushd dogecoin-${VERSION}-win-gitian
+	mkdir bitcoin-${VERSION}-win-gitian
+	pushd bitcoin-${VERSION}-win-gitian
 	unzip ../dogecoin-${VERSION}-win-gitian.zip
 	mkdir gitian
-	cp ../bitcoin/contrib/gitian-downloader/*.pgp ./gitian/
+	cp ../dogecoin/contrib/gitian-downloader/*.pgp ./gitian/
 	for signer in $(ls ../gitian.sigs/${VERSION}-win/); do
-	 cp ../gitian.sigs/${VERSION}-win/${signer}/bitcoin-build.assert ./gitian/${signer}-build.assert
-	 cp ../gitian.sigs/${VERSION}-win/${signer}/bitcoin-build.assert.sig ./gitian/${signer}-build.assert.sig
+	 cp ../gitian.sigs/${VERSION}-win/${signer}/dogecoin-build.assert ./gitian/${signer}-build.assert
+	 cp ../gitian.sigs/${VERSION}-win/${signer}/dogecoin-build.assert.sig ./gitian/${signer}-build.assert.sig
 	done
-	zip -r dogecoin-${VERSION}-win-gitian.zip *
-	cp dogecoin-${VERSION}-win-gitian.zip ../
+	zip -r bitcoin-${VERSION}-win-gitian.zip *
+	cp bitcoin-${VERSION}-win-gitian.zip ../
 	popd
 
 - Upload gitian zips to SourceForge
 
 - Announce the release:
 
-  - Add the release to bitcoin.org: https://github.com/bitcoin/bitcoin.org/tree/master/_releases
+  - Add the release to dogecoin.com
 
-  - Release sticky on bitcointalk: https://bitcointalk.org/index.php?board=1.0
+  - Announce on reddit /r/dogecoin, /r/dogecoindev
 
-  - Bitcoin-development mailing list
-
-  - Optionally reddit /r/Bitcoin, ...
+  - Release sticky on bitcointalk: https://bitcointalk.org/index.php?board=67.0
 
 - Celebrate 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -64,7 +64,7 @@ Release Process
 	./bin/gbuild ../dogecoin/contrib/gitian-descriptors/protobuf-win.yml
 	mv build/out/protobuf-*.zip inputs/
 
- Build dogecoind and dogecoin-qt on Linux32, Linux64, and Win32:
+ Build inutoshid and dogecoin-qt on Linux32, Linux64, and Win32:
   
 	./bin/gbuild --commit bitcoin=v${VERSION} ../dogecoin/contrib/gitian-descriptors/gitian-linux.yml
 	./bin/gsign --signer $SIGNER --release ${VERSION} --destination ../gitian.sigs/ ../dogecoin/contrib/gitian-descriptors/gitian-linux.yml
@@ -112,9 +112,9 @@ repackage gitian builds for release as stand-alone zip/tar/installer exe
 	export QTDIR=/opt/local/share/qt4  # needed to find translations/qt_*.qm files
 	T=$(contrib/qt_translations.py $QTDIR/translations src/qt/locale)
         export CODESIGNARGS='--keychain ...path_to_keychain --sign "Developer ID Application: DOGECOIN FOUNDATION, INC., THE"'
-	python2.7 contrib/macdeploy/macdeployqtplus Dogecoin-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
+	python2.7 contrib/macdeploy/macdeployqtplus Inutoshi-Qt.app -sign -add-qt-tr $T -dmg -fancy contrib/macdeploy/fancy.plist
 
- Build output expected: Dogecoin-Qt.dmg
+ Build output expected: Inutoshi-Qt.dmg
 
 ###Next steps:
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,7 +1,7 @@
 TOR SUPPORT IN BITCOIN
 ======================
 
-It is possible to run Bitcoin as a Tor hidden service, and connect to such services.
+It is possible to run Dogecoin as a Tor hidden service, and connect to such services.
 
 The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on a random port. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
 configure Tor.
@@ -10,7 +10,7 @@ configure Tor.
 1. Run bitcoin behind a Tor proxy
 ---------------------------------
 
-The first step is running Bitcoin behind a Tor proxy. This will already make all
+The first step is running Dogecoin behind a Tor proxy. This will already make all
 outgoing connections be anonymized, but more is possible.
 
 	-socks=5        SOCKS5 supports connecting-to-hostname, which can be used instead

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -47,11 +47,11 @@ reachable from the Tor network. Add these lines to your /etc/tor/torrc (or equiv
 config file):
 
 	HiddenServiceDir /var/lib/tor/bitcoin-service/
-	HiddenServicePort 8333 127.0.0.1:8333
-	HiddenServicePort 18333 127.0.0.1:18333
+	HiddenServicePort 22556 127.0.0.1:8333
+	HiddenServicePort 122556 127.0.0.1:18333
 
 The directory can be different of course, but (both) port numbers should be equal to
-your bitcoind's P2P listen port (8333 by default).
+your bitcoind's P2P listen port (22556 by default).
 
 	-externalip=X   You can tell bitcoin about its publicly reachable address using
 	                this option, and this can be a .onion address. Given the above
@@ -81,7 +81,7 @@ specify:
 
 	./bitcoind ... -discover
 
-and open port 8333 on your firewall (or use -upnp).
+and open port 22556 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,5 +1,5 @@
-TOR SUPPORT IN BITCOIN
-======================
+TOR SUPPORT IN DOGECOIN
+=======================
 
 It is possible to run Dogecoin as a Tor hidden service, and connect to such services.
 
@@ -36,7 +36,7 @@ outgoing connections be anonymized, but more is possible.
 
 In a typical situation, this suffices to run behind a Tor proxy:
 
-	./bitcoin -proxy=127.0.0.1:9050
+	./dogecoin -proxy=127.0.0.1:9050
 
 
 2. Run a bitcoin hidden server
@@ -46,17 +46,17 @@ If you configure your Tor system accordingly, it is possible to make your node a
 reachable from the Tor network. Add these lines to your /etc/tor/torrc (or equivalent
 config file):
 
-	HiddenServiceDir /var/lib/tor/bitcoin-service/
+	HiddenServiceDir /var/lib/tor/dogecoin-service/
 	HiddenServicePort 22556 127.0.0.1:8333
 	HiddenServicePort 122556 127.0.0.1:18333
 
 The directory can be different of course, but (both) port numbers should be equal to
-your bitcoind's P2P listen port (22556 by default).
+your dogecoind's P2P listen port (22556 by default).
 
 	-externalip=X   You can tell bitcoin about its publicly reachable address using
 	                this option, and this can be a .onion address. Given the above
 	                configuration, you can find your onion address in
-	                /var/lib/tor/bitcoin-service/hostname. Onion addresses are given
+	                /var/lib/tor/dogecoin-service/hostname. Onion addresses are given
 	                preference for your node to advertize itself with, for connections
 	                coming from unroutable addresses (such as 127.0.0.1, where the
 	                Tor proxy typically runs).
@@ -73,18 +73,18 @@ your bitcoind's P2P listen port (22556 by default).
 
 In a typical situation, where you're only reachable via Tor, this should suffice:
 
-	./bitcoind -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
+	./dogecoind -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
 
 (obviously, replace the Onion address with your own). If you don't care too much
 about hiding your node, and want to be reachable on IPv4 as well, additionally
 specify:
 
-	./bitcoind ... -discover
+	./dogecoind ... -discover
 
 and open port 22556 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:
 
-	./bitcoin -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
+	./dogecoin -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,7 +1,7 @@
 TOR SUPPORT IN DOGECOIN
 =======================
 
-It is possible to run Dogecoin as a Tor hidden service, and connect to such services.
+It is possible to run Inutoshi as a Tor hidden service, and connect to such services.
 
 The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on a random port. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
 configure Tor.
@@ -10,7 +10,7 @@ configure Tor.
 1. Run bitcoin behind a Tor proxy
 ---------------------------------
 
-The first step is running Dogecoin behind a Tor proxy. This will already make all
+The first step is running Inutoshi behind a Tor proxy. This will already make all
 outgoing connections be anonymized, but more is possible.
 
 	-socks=5        SOCKS5 supports connecting-to-hostname, which can be used instead
@@ -36,7 +36,7 @@ outgoing connections be anonymized, but more is possible.
 
 In a typical situation, this suffices to run behind a Tor proxy:
 
-	./dogecoin -proxy=127.0.0.1:9050
+	./inutoshi -proxy=127.0.0.1:9050
 
 
 2. Run a bitcoin hidden server
@@ -46,17 +46,17 @@ If you configure your Tor system accordingly, it is possible to make your node a
 reachable from the Tor network. Add these lines to your /etc/tor/torrc (or equivalent
 config file):
 
-	HiddenServiceDir /var/lib/tor/dogecoin-service/
+	HiddenServiceDir /var/lib/tor/inutoshi-service/
 	HiddenServicePort 22556 127.0.0.1:8333
 	HiddenServicePort 122556 127.0.0.1:18333
 
 The directory can be different of course, but (both) port numbers should be equal to
-your dogecoind's P2P listen port (22556 by default).
+your inutoshid's P2P listen port (22556 by default).
 
 	-externalip=X   You can tell bitcoin about its publicly reachable address using
 	                this option, and this can be a .onion address. Given the above
 	                configuration, you can find your onion address in
-	                /var/lib/tor/dogecoin-service/hostname. Onion addresses are given
+	                /var/lib/tor/inutoshi-service/hostname. Onion addresses are given
 	                preference for your node to advertize itself with, for connections
 	                coming from unroutable addresses (such as 127.0.0.1, where the
 	                Tor proxy typically runs).
@@ -73,18 +73,18 @@ your dogecoind's P2P listen port (22556 by default).
 
 In a typical situation, where you're only reachable via Tor, this should suffice:
 
-	./dogecoind -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
+	./inutoshid -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
 
 (obviously, replace the Onion address with your own). If you don't care too much
 about hiding your node, and want to be reachable on IPv4 as well, additionally
 specify:
 
-	./dogecoind ... -discover
+	./inutoshid ... -discover
 
 and open port 22556 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:
 
-	./dogecoin -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
+	./inutoshi -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
 

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -12,7 +12,7 @@ Files and Folders
 This file takes care of generating `.qm` files from `.ts` files. It is mostly
 automated.
 
-### src/qt/bitcoin.qrc
+### src/qt/dogecoin.qrc
 
 This file must be updated whenever a new translation is added. Please note that
 files must end with `.qm`, not `.ts`.

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -12,7 +12,7 @@ Files and Folders
 This file takes care of generating `.qm` files from `.ts` files. It is mostly
 automated.
 
-### src/qt/dogecoin.qrc
+### src/qt/inutoshi.qrc
 
 This file must be updated whenever a new translation is added. Please note that
 files must end with `.qm`, not `.ts`.

--- a/doc/unit-tests.md
+++ b/doc/unit-tests.md
@@ -6,13 +6,13 @@ and tests weren't explicitly disabled.
 
 After configuring, they can be run with 'make check'.
 
-To run the bitcoind tests manually, launch src/test/test_bitcoin .
+To run the dogecoind tests manually, launch src/test/test_bitcoin .
 
-To add more bitcoind tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
+To add more dogecoind tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
 .cpp files in the test/ directory or add new .cpp files that
 implement new BOOST_AUTO_TEST_SUITE sections.
 
-To run the bitcoin-qt tests manually, launch src/qt/test/bitcoin-qt_test
+To run the dogecoin-qt tests manually, launch src/qt/test/bitcoin-qt_test
 
-To add more bitcoin-qt tests, add them to the `src/qt/test/` directory and
+To add more dogecoin-qt tests, add them to the `src/qt/test/` directory and
 the `src/qt/test/test_main.cpp` file.

--- a/doc/unit-tests.md
+++ b/doc/unit-tests.md
@@ -6,9 +6,9 @@ and tests weren't explicitly disabled.
 
 After configuring, they can be run with 'make check'.
 
-To run the dogecoind tests manually, launch src/test/test_bitcoin .
+To run the inutoshid tests manually, launch src/test/test_bitcoin .
 
-To add more dogecoind tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
+To add more inutoshid tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
 .cpp files in the test/ directory or add new .cpp files that
 implement new BOOST_AUTO_TEST_SUITE sections.
 


### PR DESCRIPTION
This replaces most references to Bitcoin in the documentation with Dogecoin. Need to reconcile differences between this and Dogecoin 1.6, to ensure we're not losing attribution for work done (especially Litecoin), and no errors are introduced as a side-effect.

OS X build instructions and Berkeley DB versions for UNIX build both should be checked very carefully, as I'm unsure on both.
